### PR TITLE
Update to current upstream master

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -10,7 +10,6 @@
 // Note that the contents of incomplete uploads are not accessible even though
 // Stat returns their length
 //
-// +build include_gcs
 
 package gcs
 
@@ -39,6 +38,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/googleapi"
+	storageapi "google.golang.org/api/storage/v1"
 	"google.golang.org/cloud"
 	"google.golang.org/cloud/storage"
 )
@@ -67,6 +67,7 @@ type driverParameters struct {
 	client        *http.Client
 	rootDirectory string
 	chunkSize     int
+	projectID     string
 
 	// maxConcurrency limits the number of concurrent driver operations
 	// to GCS, which ultimately increases reliability of many simultaneous
@@ -148,6 +149,9 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 	}
 
 	var ts oauth2.TokenSource
+	var key struct {
+		ProjectID string `json:"project_id"`
+	}
 	jwtConf := new(jwt.Config)
 	if keyfile, ok := parameters["keyfile"]; ok {
 		jsonKey, err := ioutil.ReadFile(fmt.Sprint(keyfile))
@@ -156,6 +160,9 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 		}
 		jwtConf, err = google.JWTConfigFromJSON(jsonKey, storage.ScopeFullControl)
 		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(jsonKey, &key); err != nil {
 			return nil, err
 		}
 		ts = jwtConf.TokenSource(context.Background())
@@ -204,6 +211,7 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 		privateKey:     jwtConf.PrivateKey,
 		client:         oauth2.NewClient(context.Background(), ts),
 		chunkSize:      chunkSize,
+		projectID:      fmt.Sprint(key.ProjectID),
 		maxConcurrency: maxConcurrency,
 	}
 
@@ -219,6 +227,17 @@ func New(params driverParameters) (storagedriver.StorageDriver, error) {
 	if params.chunkSize <= 0 || params.chunkSize%minChunkSize != 0 {
 		return nil, fmt.Errorf("Invalid chunksize: %d is not a positive multiple of %d", params.chunkSize, minChunkSize)
 	}
+
+	service, err := storageapi.New(params.client)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := service.Buckets.Get(params.bucket).Do(); err != nil {
+		if _, err := service.Buckets.Insert(params.projectID, &storageapi.Bucket{Name: params.bucket}).Do(); err != nil {
+			return nil, err
+		}
+	}
+
 	d := &driver{
 		bucket:        params.bucket,
 		rootDirectory: rootDirectory,
@@ -540,6 +559,9 @@ func (w *writer) Write(p []byte) (int, error) {
 
 // Size returns the number of bytes written to this FileWriter.
 func (w *writer) Size() int64 {
+	if !w.closed {
+		return w.offset + int64(w.buffSize)
+	}
 	return w.size
 }
 

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -1,5 +1,3 @@
-// +build include_gcs
-
 package gcs
 
 import (
@@ -8,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"fmt"
+	ctx "github.com/docker/distribution/context"
 	dcontext "github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/testsuites"

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -460,6 +460,23 @@ func New(params DriverParameters) (*Driver, error) {
 		setv2Handlers(s3obj)
 	}
 
+	_, err = s3obj.CreateBucket(&s3.CreateBucketInput{
+		Bucket: &params.Bucket,
+	})
+	if err != nil {
+		if s3err, ok := err.(awserr.Error); ok {
+			if s3err.Code() != "BucketAlreadyOwnedByYou" && s3err.Code() != "BucketAlreadyExists" {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	if err := s3obj.WaitUntilBucketExists(&s3.HeadBucketInput{Bucket: &params.Bucket}); err != nil {
+		return nil, err
+	}
+
 	// TODO Currently multipart uploads have no timestamps, so this would be unwise
 	// if you initiated a new s3driver while another one is running on the same bucket.
 	// multis, _, err := bucket.ListMulti("", "")

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -116,7 +116,7 @@ type FileWriter interface {
 // number of path components separated by slashes, where each component is
 // restricted to alphanumeric characters or a period, underscore, or
 // hyphen.
-var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._-]+)+$`)
+var PathRegexp = regexp.MustCompile(`^([A-Za-z0-9._:-]*(/[A-Za-z0-9._:-]+)*)+$`)
 
 // ErrUnsupportedMethod may be returned in the case where a StorageDriver implementation does not support an optional method.
 type ErrUnsupportedMethod struct {


### PR DESCRIPTION
Hi!

This is an update to upstream master (https://github.com/docker/distribution/commit/1cb4180b1a5b9c029b2f2beaeb38f0b5cf64e12e), plus https://github.com/teamhephy/distribution/commit/0afef00d5764404d70f86076f364551657d51de6, which I think was the only change (I re-commited that because I couldn't quite get git to do what I want).

Obviously, this diff is huge, but if you do a `git remote add docker git@github.com:docker/distribution.git`and then do `git diff docker/master`, you'll see [just this](https://gist.github.com/rwos/d9c9af379c9be6d9d2ba43b874cd110e), which is essentially equal to https://github.com/teamhephy/distribution/commit/0afef00d5764404d70f86076f364551657d51de6.

Background: What I *actually* want to fix is https://github.com/teamhephy/workflow/issues/52 - I did that by adding an `s3.endpoint` values.yaml parameter, and using that everywhere (I currently have this all running locally, will do PRs to all the components over the next days).

That *should* have worked without updating this lib here, but - at least with the particular kind of S3-compatible storage I'm using - I ran into some sort of bug in the aws SDK or something, which disappeared after updating this. Also, maybe updating this dependency after 3 years isn't such a bad idea in general ;)

Let me know if there's questions about any of the above! :)